### PR TITLE
Add eventTime value (required by CJ)

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -81,7 +81,14 @@ ___TEMPLATE_PARAMETERS___
         "displayName": "Purchase amount",
         "simpleValueType": true,
         "help": "Default to \"value - tax - shipping\""
-      }
+      },
+      {
+        "type": "TEXT",
+        "name": "orderDateTime",
+        "displayName": "Order Date Time",
+        "simpleValueType": true,
+        "help": "Date and Time in ISO 8601 of the order"
+      },
     ]
   },
   {
@@ -156,6 +163,7 @@ const setCookie = require('setCookie');
 const getCookieValues = require('getCookieValues');
 const parseUrl = require('parseUrl');
 const encodeUriComponent = require('encodeUriComponent');
+const makeString = require('makeString');
 
 const eventModel = getAllEventData();
 const API_ENDPOINT = 'https://www.emjcd.com/u';
@@ -196,12 +204,13 @@ switch (eventModel.event_name) {
     const cjeCookie = getCookieValues('cje');
 
     if (cjeCookie && cjeCookie[0]) {
+        const eventTime = safeEncodeUriComponent(makeString(data.orderDateTime || eventModel.orderDateTime || ''));
         let urlParams = [
           'cid=' + data.cid,
           'type=' + data.actionId,
           'method=S2S',
           'cjevent=' + cjeCookie[0],
-          'eventTime=',
+          'eventTime=' + eventTime,
           'oid=' + safeEncodeUriComponent(eventModel.transaction_id),
           'currency=' + eventModel.currency,
           'coupon=' + safeEncodeUriComponent(eventModel.coupon),


### PR DESCRIPTION
Add a value for eventTime due to CJ requirements (https://developers.cj.com/docs/data-imports/new-orders-data)

Field | Description and Requirements | Example | Required
-- | -- | -- | --
eventTime | ISO 8601 standard format with Z as the zone designator for the zero UTC offset:yyyy-mm-ddThh24:mm:ss+/-hh:mmyyyy-mm-ddThh24:mm:ssZNote: Future dates are not accepted. If a format with no time zone offset is used, the time zone will default to UTC.The following date and time formats are also supported, but time zone cannot be defined. CJ will interpret the date and time as UTC for the following:MM/DD/YYYY HH24:MI:SSMM/DD/YYYY HH12:MI AM/PMYYYY-MM-DD HH24:MI:SSdd-MMM-yyyy HH:mm | 1970-03-27T12:13:14-05:001970-03-27T12:18:14Z09/15/2023 14:30:4509/15/2023 02:30 PM2023-09-15 14:30:4515-Sep-2023 14:30 | Yes

